### PR TITLE
highflow-expert commit 4

### DIFF
--- a/example/StreamflowExample-DI.py
+++ b/example/StreamflowExample-DI.py
@@ -33,7 +33,7 @@ interfaceOpt = 1
 # ==0, the original "pro" version to train jobs based on the defined configuration dictionary.
 # Results are very similar for two options.
 
-flow_regime = 0
+flow_regime = 1
 # 0: low flow expert
 # 1: high flow expert
 
@@ -76,7 +76,7 @@ torch.backends.cudnn.benchmark = False
 # Then 'rootDatabase' here should be 'your/path/to/Camels'
 # You can also define the database directory in hydroDL/__init__.py by modifying pathCamels['DB'] variable
 rootDatabase = os.path.join(os.sep,"scratch", "Camels")  # CAMELS dataset root directory: /scratch/Camels
-camels.initcamels(flow_regime=flow_regime, rootDB=rootDatabase)  # initialize three camels module-scope variables in camels.py: dirDB, gageDict, statDict
+camels.initcamels(flow_regime=flow_regime, rootDB=rootDatabase, forType=forType)  # initialize three camels module-scope variables in camels.py: dirDB, gageDict, statDict
 
 rootOut = os.path.join(
     os.sep, "data", "kas7897", "lstm_tuning", "hydroDL", "output", "rnnStreamflow"
@@ -171,7 +171,7 @@ optTrain = default.update(
 )
 
 # define output folder for model results
-exp_name = f"CAMELSDemo"
+exp_name = f"CAMELSDemo{seedid}"
 exp_disp = "TestRun"
 save_path = os.path.join(
     exp_name,

--- a/hydroDL/data/camels.py
+++ b/hydroDL/data/camels.py
@@ -413,7 +413,7 @@ def calStatbasinnorm(
     return [p10, p90, mean, std]
 
 
-def calStatAll(flow_regime):
+def calStatAll(flow_regime=0, forType='daymet', nt=nt):
     statDict = dict()
     idLst = gageDict["id"]
     # usgs streamflow
@@ -421,7 +421,7 @@ def calStatAll(flow_regime):
     # statDict['usgsFlow'] = calStatgamma(y)
     statDict["usgsFlow"] = calStatbasinnorm(y)
     # forcing
-    x = readForcing(idLst, forcingLst)
+    x = readForcing(idLst, forcingLst, forType, nt)
     for k in range(len(forcingLst)):
         var = forcingLst[k]
         if flow_regime==0:
@@ -622,14 +622,22 @@ else:
     statDict = None
 
 
-def initcamels(flow_regime, rootDB=pathCamels["DB"]):
+def initcamels(flow_regime, forType, rootDB=pathCamels["DB"]):
     # reinitialize module variable
     global dirDB, gageDict, statDict
     dirDB = rootDB
     gageDict = readGageInfo(dirDB)
     statFile = os.path.join(dirDB, "Statistics_basinnorm.json")
     if not os.path.isfile(statFile):
-        calStatAll(flow_regime=flow_regime)
+        if forType in ['maurer', 'maurer_extended']:
+            tRange = [19800101, 20090101]
+        elif forType in ['fused', 'fused_prcp']:
+            tRange = [19801001, 20051001]
+        else:
+            tRange = [19800101, 20150101]
+        tLst = utils.time.tRange2Array(tRange)
+        nt = len(tLst)
+        calStatAll(flow_regime=flow_regime, forType=forType, nt=nt)
     with open(statFile, "r") as fp:
         statDict = json.load(fp)
 


### PR DESCRIPTION
What was done:
1. Fixed a bug with calstatAll() in camels.py, initiated inputs for 'forType' and 'nt'

Discovered that statistics_basinnorm.json created in root data folder 'might be redundant and not of further used during training.'

Checked:
1. By seeing if the code is running bug free when statistics_basinnorm.json does not exist in root data folder.